### PR TITLE
Fix `kalmanBucyFilter` for implicit calculation of mean with intercapts in drift terms

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -69,8 +69,8 @@ calc_filter_vcov_are <- function(un_dr_sl, un_diff, ob_dr_sl, ob_diff) {
     .Call('_yuima_calc_filter_vcov_are', PACKAGE = 'yuima', un_dr_sl, un_diff, ob_dr_sl, ob_diff)
 }
 
-calc_filter_mean_explicit <- function(un_dr_sl, ob_dr_sl, ob_diff, vcov, init, delta, deltaY) {
-    .Call('_yuima_calc_filter_mean_explicit', PACKAGE = 'yuima', un_dr_sl, ob_dr_sl, ob_diff, vcov, init, delta, deltaY)
+calc_filter_mean_explicit <- function(un_dr_sl, un_dr_in, ob_dr_sl, ob_dr_in, ob_diff, vcov, init, delta, deltaY) {
+    .Call('_yuima_calc_filter_mean_explicit', PACKAGE = 'yuima', un_dr_sl, un_dr_in, ob_dr_sl, ob_dr_in, ob_diff, vcov, init, delta, deltaY)
 }
 
 W1 <- function(crossdx, b, A, h) {

--- a/R/kalmanBucyFilter.R
+++ b/R/kalmanBucyFilter.R
@@ -127,7 +127,9 @@ kalmanBucyFilter <- function(yuima, params, mean_init, vcov_init = NULL, delta.v
             vcov <- res
             mean <- calc_filter_mean_explicit(
                 unobserved.drift.slope,
+                unobserved.drift.intercept,
                 observed.drift.slope,
+                observed.drift.intercept,
                 observed.diffusion,
                 vcov,
                 mean_init,

--- a/man/kalmanBucyFilter.Rd
+++ b/man/kalmanBucyFilter.Rd
@@ -22,7 +22,7 @@ kalmanBucyFilter(
     This is required if \code{are = FALSE}. It can be a numeric of length 1 if the number of observed variables is 1.}
   \item{delta.vcov.solve}{A numeric value representing the step size in solving the mean squared error of the estimator.}
   \item{are}{A logical value. If \code{TRUE}, solve the algebraic Riccati equation.}
-  \item{explicit}{A logical value. If \code{TRUE}, use the explicit formula to solve the filtering equation.}
+  \item{explicit}{A logical value. If \code{TRUE}, use the explicit formula to solve the filtering equation. The formula is available only if coefficients are time-independent.}
   \item{env}{An environment. The environment in which the model coefficients are evaluated.}
 }
 \value{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -258,19 +258,21 @@ BEGIN_RCPP
 END_RCPP
 }
 // calc_filter_mean_explicit
-arma::mat calc_filter_mean_explicit(arma::mat un_dr_sl, arma::mat ob_dr_sl, arma::mat ob_diff, arma::mat vcov, arma::vec init, double delta, arma::mat deltaY);
-RcppExport SEXP _yuima_calc_filter_mean_explicit(SEXP un_dr_slSEXP, SEXP ob_dr_slSEXP, SEXP ob_diffSEXP, SEXP vcovSEXP, SEXP initSEXP, SEXP deltaSEXP, SEXP deltaYSEXP) {
+arma::mat calc_filter_mean_explicit(arma::mat un_dr_sl, arma::mat un_dr_in, arma::mat ob_dr_sl, arma::mat ob_dr_in, arma::mat ob_diff, arma::mat vcov, arma::vec init, double delta, arma::mat deltaY);
+RcppExport SEXP _yuima_calc_filter_mean_explicit(SEXP un_dr_slSEXP, SEXP un_dr_inSEXP, SEXP ob_dr_slSEXP, SEXP ob_dr_inSEXP, SEXP ob_diffSEXP, SEXP vcovSEXP, SEXP initSEXP, SEXP deltaSEXP, SEXP deltaYSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< arma::mat >::type un_dr_sl(un_dr_slSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type un_dr_in(un_dr_inSEXP);
     Rcpp::traits::input_parameter< arma::mat >::type ob_dr_sl(ob_dr_slSEXP);
+    Rcpp::traits::input_parameter< arma::mat >::type ob_dr_in(ob_dr_inSEXP);
     Rcpp::traits::input_parameter< arma::mat >::type ob_diff(ob_diffSEXP);
     Rcpp::traits::input_parameter< arma::mat >::type vcov(vcovSEXP);
     Rcpp::traits::input_parameter< arma::vec >::type init(initSEXP);
     Rcpp::traits::input_parameter< double >::type delta(deltaSEXP);
     Rcpp::traits::input_parameter< arma::mat >::type deltaY(deltaYSEXP);
-    rcpp_result_gen = Rcpp::wrap(calc_filter_mean_explicit(un_dr_sl, ob_dr_sl, ob_diff, vcov, init, delta, deltaY));
+    rcpp_result_gen = Rcpp::wrap(calc_filter_mean_explicit(un_dr_sl, un_dr_in, ob_dr_sl, ob_dr_in, ob_diff, vcov, init, delta, deltaY));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/kalmanBucyFilter.cpp
+++ b/src/kalmanBucyFilter.cpp
@@ -105,12 +105,14 @@ arma::mat calc_filter_vcov_are(arma::mat un_dr_sl, arma::mat un_diff, arma::mat 
 }
 
 //[[Rcpp::export]]
-arma::mat calc_filter_mean_explicit(arma::mat un_dr_sl, arma::mat ob_dr_sl, arma::mat ob_diff, arma::mat vcov, arma::vec init, double delta, arma::mat deltaY) {
+arma::mat calc_filter_mean_explicit(arma::mat un_dr_sl, arma::mat un_dr_in, arma::mat ob_dr_sl, arma::mat ob_dr_in, arma::mat ob_diff, arma::mat vcov, arma::vec init, double delta, arma::mat deltaY) {
     /*
     calculate mean explicitly if coefficients are time-independent.
     use when estimated vcov with Algebric Riccati Equation.
     
-    m_{i+1} = \exp(-\alpha(\theta1, \theta2)h)m_{i} + \exp(-\alpha(\theta1, \theta2)h)\gamma(\theta1, \theta2)c(\theta2)^T\Sigma)\theta1)^{-1}\Delta_{i+1}Y
+    m_{i+1} = e*m_{i} + e*a_2*h + e*\gamma(\theta1, \theta2)c(\theta2)^T\Sigma(\theta1)^{-1}\Delta_{i+1}Y + e*\gamma(\theta1, \theta2)c(\theta2)^T\Sigma(\theta1)^{-1}*c_2*h
+    where 
+    e = \exp(-\alpha(\theta1, \theta2)h)
     \alpha(\theta1, \theta2) = a(\theta1) + \gamma(\theta1, \theta2)c(\theta2)^T\Sigma(\theta1)c(\theta2)
     \Sigma = \sigma(\theta1)\sigma^T(\theta1)
     */
@@ -127,7 +129,7 @@ arma::mat calc_filter_mean_explicit(arma::mat un_dr_sl, arma::mat ob_dr_sl, arma
 
     for(int i = 1; i < n_data; i++){
         arma::vec mean_prev = mean.col(i - 1);
-        arma::vec mean_next = exp_alpha_h * mean_prev + deltaY_coeff * deltaY.col(i-1);
+        arma::vec mean_next = exp_alpha_h * mean_prev + exp_alpha_h * un_dr_in * delta + deltaY_coeff * deltaY.col(i-1) + deltaY_coeff * ob_dr_in * delta;
         mean.col(i) = mean_next;
     }
 
@@ -144,7 +146,7 @@ vcov = calc_filter_vcov_are(un_dr_sl, un_diff, ob_dr_sl, ob_diff)
 mean_init <- c(1,1,1)
 delta <- 0.1
 deltaY <- matrix(rnorm(6), nrow=2)
-calc_filter_mean_explicit(un_dr_sl, ob_dr_sl, ob_diff, vcov, mean_init, delta, deltaY)
+calc_filter_mean_explicit(un_dr_sl, un_dr_in, ob_dr_sl, ob_dr_in, ob_diff, vcov, mean_init, delta, deltaY)
 */
 /*
 un_dr_sl <- array(rep(1:9, 4), dim = c(3, 3, 4))

--- a/src/yuima_init.c
+++ b/src/yuima_init.c
@@ -60,7 +60,7 @@ extern SEXP _yuima_calc_filter_mean(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SE
 extern SEXP _yuima_minusloglcpp_linear_state_space_theta1(SEXP,SEXP,SEXP, SEXP);
 extern SEXP _yuima_minusloglcpp_linear_state_space_theta2(SEXP,SEXP,SEXP, SEXP, SEXP);
 extern SEXP _yuima_calc_filter_vcov_are(SEXP, SEXP, SEXP, SEXP);
-extern SEXP _yuima_calc_filter_mean_explicit(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _yuima_calc_filter_mean_explicit(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 static const R_CMethodDef CEntries[] = {
     {"bibsynchro",         (DL_FUNC) &bibsynchro,          9},
@@ -117,7 +117,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_yuima_minusloglcpp_linear_state_space_theta1", (DL_FUNC) &_yuima_minusloglcpp_linear_state_space_theta1, 4},
     {"_yuima_minusloglcpp_linear_state_space_theta2", (DL_FUNC) &_yuima_minusloglcpp_linear_state_space_theta2, 5},
     {"_yuima_calc_filter_vcov_are",                   (DL_FUNC) &_yuima_calc_filter_vcov_are,                          4},
-    {"_yuima_calc_filter_mean_explicit",              (DL_FUNC) &_yuima_calc_filter_mean_explicit,                     7},
+    {"_yuima_calc_filter_mean_explicit",              (DL_FUNC) &_yuima_calc_filter_mean_explicit,                     9},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Updated `kalmanBucyFilter` to enable implicit calculation of mean with intercapts in drift terms.

Note: It seems that the convergence of theta1 becomes slower in case intercapts are in drift terms. 