### PR TITLE
fix: restore defninition of adabayes class

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -264,3 +264,18 @@ setMethod(
 setMethod("summary", "yuima.kalmanBucyFilter", function(object) {
   print(object)
 })
+
+# adaBayes related
+setClass(
+  "adabayes",
+  #contains = "mle",
+  slots = c(
+    mcmc = "list",
+    accept_rate = "list",
+    coef = "numeric",
+    call = "call",
+    vcov = "matrix",
+    fullcoef = "numeric",
+    fixed = "numeric"
+  )
+)

--- a/R/adaBayes.R
+++ b/R/adaBayes.R
@@ -896,9 +896,9 @@ setMethod(
 
     fulcoef <- unlist(mycoef)
 
-    new("yuima.adabayes", mcmc = mcmc, accept_rate = accept_rate, coef = fulcoef, call = call, vcov = vcov, fullcoef = fulcoef, fixed = numeric(0))
+    new("adabayes", mcmc = mcmc, accept_rate = accept_rate, coef = fulcoef, call = call, vcov = vcov, fullcoef = fulcoef, fixed = numeric(0))
   }
 )
 
 setGeneric("coef")
-setMethod("coef", "yuima.adabayes", function(object) object@fullcoef)
+setMethod("coef", "adabayes", function(object) object@fullcoef)


### PR DESCRIPTION
Fixed message on installation
```
in method for ‘coef’ with signature ‘"yuima.adabayes"’: no definition for class “yuima.adabayes”
```